### PR TITLE
find lindroid devices in /dev/dri/by-path/

### DIFF
--- a/create-disp.cpp
+++ b/create-disp.cpp
@@ -179,6 +179,12 @@ bool is_evdi_lindroid(int fd) {
     return false;
 }
 
+bool ends_with_card(const std::string& str) {
+    const std::string suffix = "-card";
+    if (str.size() < suffix.size()) return false;
+    return str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
 int find_evdi_lindroid_device() {
     const std::string dri_path = "/dev/dri/by-path/";
     std::vector<std::string> candidates;
@@ -186,7 +192,9 @@ int find_evdi_lindroid_device() {
     if (DIR* dir = opendir(dri_path.c_str())) {
         struct dirent* entry;
         while ((entry = readdir(dir)) != nullptr) {
-        	candidates.emplace_back(dri_path + entry->d_name);
+			if (ends_with_card(entry->d_name)) {
+        		candidates.emplace_back(dri_path + entry->d_name);
+			}
         }
         closedir(dir);
     }


### PR DESCRIPTION
My kernel is having this behaviour:
```
root@lindroid:~# ls /dev/dri
by-path
root@lindroid:~# ls /dev/dri/by-path/
platform-evdi-lindroid.0-card   platform-evdi-lindroid.12-card  platform-evdi-lindroid.15-card  platform-evdi-lindroid.3-card  platform-evdi-lindroid.6-card  platform-evdi-lindroid.9-card
platform-evdi-lindroid.10-card  platform-evdi-lindroid.13-card  platform-evdi-lindroid.1-card   platform-evdi-lindroid.4-card  platform-evdi-lindroid.7-card
platform-evdi-lindroid.11-card  platform-evdi-lindroid.14-card  platform-evdi-lindroid.2-card   platform-evdi-lindroid.5-card  platform-evdi-lindroid.8-card
```