### PR TITLE
run the create-disp service under root

### DIFF
--- a/create-disp.service
+++ b/create-disp.service
@@ -5,7 +5,6 @@ After=sysinit.target
 [Service]
 Restart=always
 RestartSec=1
-User=lindroid
 ExecStart=/usr/bin/create-disp
 
 [Install]


### PR DESCRIPTION
because it needs root permission to drop master