### PR TITLE
Improvements

### DIFF
--- a/create-disp.cpp
+++ b/create-disp.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <climits>
 #include <chrono>
+#include <poll.h>
 
 #include <systemd/sd-daemon.h>
 
@@ -398,6 +399,13 @@ void swap_to_buff(void *data, int poll_id, int drm_fd) {
         error =hwc2_compat_display_present(hwcDisplay, &presentFence);
 	if (error != HWC2_ERROR_NONE) {
 		std::cerr << "Failed to present display: " << error << std::endl;
+	}
+	if (presentFence >= 0) {
+		struct pollfd pfd;
+		pfd.fd = presentFence;
+		pfd.events = POLLIN;
+		(void)poll(&pfd, 1, -1);
+		close(presentFence);
 	}
 done:
 	struct drm_evdi_swap_callback cmd = {.poll_id=poll_id};

--- a/create-disp.cpp
+++ b/create-disp.cpp
@@ -521,8 +521,10 @@ int main() {
 
     while (true) {
         ret = ioctl(fd, DRM_IOCTL_EVDI_POLL, &poll_cmd);
-        if(ret)
+        if(ret < 0) {
+            usleep(1000);
             continue;
+        }
 	printf("Got event: %d\n", poll_cmd.event);
         switch(poll_cmd.event) {
            case add_buf:

--- a/create-disp.cpp
+++ b/create-disp.cpp
@@ -70,6 +70,7 @@ struct HandleInfo {
 
 hwc2_compat_display_t* hwcDisplay;
 hwc2_compat_device_t* hwcDevice;
+static std::unordered_map<int, std::unique_ptr<RemoteWindowBuffer>> buffers_map;
 std::unordered_map<int, std::unique_ptr<native_handle_t>> handles_map;
 int global_width, global_height;
 uint32_t global_stride;
@@ -387,9 +388,17 @@ void swap_to_buff(void *data, int poll_id, int drm_fd) {
                 goto done;
         } 
 
-	uint32_t  stride;
-
-        buf = new RemoteWindowBuffer(global_width, global_height, global_stride, HAL_PIXEL_FORMAT_RGBA_8888, GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_COMPOSER, in_handle);
+	{
+	auto it_buf = buffers_map.find(id);
+	if (it_buf == buffers_map.end()) {
+		auto new_buf = std::make_unique<RemoteWindowBuffer>(
+			global_width, global_height, global_stride,
+			HAL_PIXEL_FORMAT_RGBA_8888,
+			GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_COMPOSER, in_handle);
+		buf = new_buf.get();
+		buffers_map[id] = std::move(new_buf);
+	} else { buf = it_buf->second.get(); }
+	}
 	hwc2_error_t error;
         hwc2_compat_display_set_client_target(hwcDisplay, /* slot */0, buf,
                                               -1,
@@ -420,6 +429,7 @@ void destroy_buff(void *data, int poll_id, int drm_fd) {
         if(handle) {
                 native_handle_close(handle);
         }
+	buffers_map.erase(id);
         handles_map.erase(id);
         struct drm_evdi_destroy_buff_callback cmd = {.poll_id=poll_id};
         ret=ioctl(drm_fd, DRM_IOCTL_EVDI_DESTROY_BUFF_CALLBACK, &cmd);


### PR DESCRIPTION
 - Wait for frame for DRM_IOCTL_EVDI_SWAP_CALLBACK
 - Stop hammering kernel on poll ioctl -1
 - Cache RemoteWindowBuffer objects
 
 First change is needed for moving lindroid-drm-loopback page flip and fb destroy non blocking and improves timing. However, these changes are still usable on older lindroid-drm-loopback as well.